### PR TITLE
Support changing other properties besides brightness

### DIFF
--- a/src/Kaleidoscope-LEDEffect-Rainbow.cpp
+++ b/src/Kaleidoscope-LEDEffect-Rainbow.cpp
@@ -24,6 +24,20 @@ void LEDRainbowEffect::brightness(byte brightness) {
 
 
 // ---------
+LEDRainbowWaveEffect::LEDRainbowWaveEffect(byte brightness) {
+  this->brightness(brightness);
+}
+
+LEDRainbowWaveEffect::LEDRainbowWaveEffect(byte brightness, uint16_t delay) {
+  this->brightness(brightness);
+  this->delay(delay);
+}
+
+LEDRainbowWaveEffect::LEDRainbowWaveEffect(byte brightness, uint16_t delay, uint8_t precision) {
+  this->brightness(brightness);
+  this->delay(delay);
+  this->precision(precision);
+}
 
 void LEDRainbowWaveEffect::update(void) {
   if (rainbow_current_ticks++ < rainbow_wave_ticks) {
@@ -49,6 +63,15 @@ void LEDRainbowWaveEffect::update(void) {
 void LEDRainbowWaveEffect::brightness(byte brightness) {
   rainbow_value = brightness;
 }
+
+void LEDRainbowWaveEffect::delay(uint16_t delay_ticks) {
+  rainbow_wave_ticks = delay_ticks;
+}
+
+void LEDRainbowWaveEffect::precision(uint8_t hues_to_skip) {
+  rainbow_wave_steps = hues_to_skip;
+}
+
 }
 
 kaleidoscope::LEDRainbowEffect LEDRainbowEffect;

--- a/src/Kaleidoscope-LEDEffect-Rainbow.h
+++ b/src/Kaleidoscope-LEDEffect-Rainbow.h
@@ -6,7 +6,7 @@
 namespace kaleidoscope {
 class LEDRainbowEffect : public LEDMode {
  public:
-  LEDRainbowEffect(void) {}
+  LEDRainbowEffect(void) {}  //  Empty constructor with default values
 
   void brightness(byte);
   void update(void) final;
@@ -19,26 +19,30 @@ class LEDRainbowEffect : public LEDMode {
   uint16_t rainbow_ticks = 10;  //  delays between update
 
   byte rainbow_saturation = 255;
-  byte rainbow_value = 50;
+  byte rainbow_value = 151;
 };
 
 
 class LEDRainbowWaveEffect : public LEDMode {
  public:
-  LEDRainbowWaveEffect(void) {}
+  LEDRainbowWaveEffect(void) {} //  Empty constructor with default values
+  LEDRainbowWaveEffect(byte);
+  LEDRainbowWaveEffect(byte, uint16_t);
+  LEDRainbowWaveEffect(byte, uint16_t, uint8_t);
 
   void brightness(byte);
+  void delay(uint16_t);
+  void precision(uint8_t);
   void update(void) final;
 
  private:
   uint16_t rainbow_hue = 0;  //  stores 0 to 614
-
   uint8_t rainbow_wave_steps = 1;  //  number of hues we skip in a 360 range per update
-  uint16_t rainbow_current_ticks = 0;
+  uint16_t rainbow_current_ticks = 0; //  the current tick in the cycle
   uint16_t rainbow_wave_ticks = 10;  //  delays between update
 
   byte rainbow_saturation = 255;
-  byte rainbow_value = 50;
+  byte rainbow_value = 151;
 };
 }
 


### PR DESCRIPTION
Add support for changing other properties besides brightness.  This allows us to speed up the rainbow effect in various ways (or, potentially, to slow it down).