### PR TITLE
Use timers instead of ticks to time when to update the effects

### DIFF
--- a/src/Kaleidoscope-LEDEffect-Rainbow.cpp
+++ b/src/Kaleidoscope-LEDEffect-Rainbow.cpp
@@ -3,10 +3,11 @@
 namespace kaleidoscope {
 
 void LEDRainbowEffect::update(void) {
-  if (rainbow_current_ticks++ < rainbow_ticks) {
+  uint16_t now = millis();
+  if ((now - rainbow_last_update) < rainbow_update_delay) {
     return;
   } else {
-    rainbow_current_ticks = 0;
+    rainbow_last_update = now;
   }
 
   cRGB rainbow = hsvToRgb(rainbow_hue, rainbow_saturation, rainbow_value);
@@ -26,10 +27,11 @@ void LEDRainbowEffect::brightness(byte brightness) {
 // ---------
 
 void LEDRainbowWaveEffect::update(void) {
-  if (rainbow_current_ticks++ < rainbow_wave_ticks) {
+  uint16_t now = millis();
+  if ((now - rainbow_last_update) < rainbow_update_delay) {
     return;
   } else {
-    rainbow_current_ticks = 0;
+    rainbow_last_update = now;
   }
 
   for (uint8_t i = 0; i < LED_COUNT; i++) {

--- a/src/Kaleidoscope-LEDEffect-Rainbow.h
+++ b/src/Kaleidoscope-LEDEffect-Rainbow.h
@@ -15,8 +15,8 @@ class LEDRainbowEffect : public LEDMode {
   uint16_t rainbow_hue = 0;   //  stores 0 to 614
 
   uint8_t rainbow_steps = 1;  //  number of hues we skip in a 360 range per update
-  uint16_t rainbow_current_ticks = 0;
-  uint16_t rainbow_ticks = 10;  //  delays between update
+  uint16_t rainbow_last_update = 0;
+  uint16_t rainbow_update_delay = 40; // delay between updates (ms)
 
   byte rainbow_saturation = 255;
   byte rainbow_value = 50;
@@ -34,8 +34,8 @@ class LEDRainbowWaveEffect : public LEDMode {
   uint16_t rainbow_hue = 0;  //  stores 0 to 614
 
   uint8_t rainbow_wave_steps = 1;  //  number of hues we skip in a 360 range per update
-  uint16_t rainbow_current_ticks = 0;
-  uint16_t rainbow_wave_ticks = 10;  //  delays between update
+  uint16_t rainbow_last_update = 0;
+  uint16_t rainbow_update_delay = 40; // delay between updates (ms)
 
   byte rainbow_saturation = 255;
   byte rainbow_value = 50;


### PR DESCRIPTION
Ticks depend on the speed of the main loop, and as such, are not a reliable way to time animations. For this reason, use proper timers instead.

The update delay is set to 40ms, which appears to be a slow, relaxing animation, and should be roughly in the ballpark the tick-based timing was, before speeding up the main loop considerably.

Fixes #3.
