### PR TITLE
Sorry! there was a spelling error in the code in the last PR that kept it from compiling!

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ void setup() {
 
   LEDRainbowEffect.brightness(150);
   LEDRainbowWaveEffect.brightness(150);
-  LEDRainbowWaveEffect.delay(50);
+  LEDRainbowWaveEffect.update_delay(50);
 }
 ```
 

--- a/src/Kaleidoscope-LEDEffect-Rainbow.cpp
+++ b/src/Kaleidoscope-LEDEffect-Rainbow.cpp
@@ -56,7 +56,7 @@ void LEDRainbowWaveEffect::brightness(byte brightness) {
   rainbow_value = brightness;
 }
 
-void LEDRainbowWaveEffect::updat_delay(byte delay) {
+void LEDRainbowWaveEffect::update_delay(byte delay) {
   rainbow_update_delay = delay;
 }
 }


### PR DESCRIPTION
named one of the methods `.updat_delay` instead of the `.update_delay` that is in the header and documentation. Fails to compile if you try to call it in your sketch! Sorry for not catching this the first time around.