### PR TITLE
Cleanup, saturation and breathe

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,30 +30,55 @@ KALEIDOSCOPE_INIT_PLUGINS(LEDRainbowEffect, LEDRainbowWaveEffect);
 void setup() {
   Kaleidoscope.setup();
 
-  LEDRainbowEffect.brightness(150);
-  LEDRainbowWaveEffect.brightness(150);
-  LEDRainbowWaveEffect.update_delay(50);
+  LEDRainbowEffect.breathe = true;
+  LEDRainbowEffect.hue_update_interval = 128;
+  // to get a full hue cycle in ‘n’ breath cycles,
+  // set the hue_update_interval to ‘n × 16’
+
+  LEDRainbowWaveEffect.saturation = 200;
+  LEDRainbowWaveEffect.hue_steps = -1;
+  LEDRainbowWaveEffect.brightness = 150;
 }
 ```
 
-## Plugin methods
+## Plugin properties
 
 The plugin provides two objects: `LEDRainbowEffect`, and `LEDRainbowWaveEffect`,
-both of which provide the following methods:
+both of which provide the following properties:
 
-### `.brightness([brightness])`
+### `.hue_steps`
 
-> Sets (or gets, if called without an argument) the LED brightness for the
-> effect.
+> The number of steps the hue is changed every `hue_update_interval`
+> milliseconds. Smaller values make smoother rainbows. Negative values make
+> reverse rainbows.
 >
-> Defaults to 50.
+> Defaults to +1.
 
-### `.update_delay([delay])`
+### `.hue_update_interval`
 
-> Sets (or gets, if called without an argument) the number of milliseconds
-> between effect updates. Smaller number results in faster rainbows.
+> The number of milliseconds between hue updates. Smaller values make faster
+> rainbows.
 >
 > Defaults to 40.
+
+### `.saturation`
+
+> The saturation of the rainbow colors. Lesser values result in more pastel
+> colors and greater ones result in more vibrant colors.
+>
+> Defaults to 255 (max).
+
+### `.breathe`
+
+> Whether the rainbow effect is to be mixed with a "breathe" effect or not.
+>
+> Defaults to `false`.
+
+### `.brightness`
+
+> The LED brightness for the effect if breathing is not enabled.
+>
+> Defaults to 50.
 
 ## Dependencies
 

--- a/src/Kaleidoscope-LEDEffect-Rainbow.cpp
+++ b/src/Kaleidoscope-LEDEffect-Rainbow.cpp
@@ -1,17 +1,19 @@
 #include "Kaleidoscope-LEDEffect-Rainbow.h"
+#define UPDATE_INTERVAL 50  // milliseconds between two LED updates to avoid overloading; 20 fps
 
 namespace kaleidoscope {
 
 void LEDRainbowEffect::update(void) {
   uint16_t now = millis();
   if ((now - last_hue_update) < hue_update_interval) {
-    if (!breathe) { // no updates either due to hue change or breathing
+    if (!breathe || (now - last_update) < UPDATE_INTERVAL) {  // no updates either due to hue change or breathing
       return;
     }
   } else {
     hue += hue_steps;
     last_hue_update = now;
   }
+  last_update = now;
 
   cRGB rainbow = breathe ?
                  breath_compute_helper(hue, saturation, now) :
@@ -24,13 +26,14 @@ void LEDRainbowEffect::update(void) {
 void LEDRainbowWaveEffect::update(void) {
   uint16_t now = millis();
   if ((now - last_hue_update) < hue_update_interval) {
-    if (!breathe) { // no updates either due to hue change or breathing
+    if (!breathe || (now - last_update) < UPDATE_INTERVAL) {  // no updates either due to hue change or breathing
       return;
     }
   } else {
     hue += hue_steps;
     last_hue_update = now;
   }
+  last_update = now;
 
   for (uint8_t i = 0; i < LED_COUNT; i++) {
     uint16_t key_hue = hue + 16 * (i / 4);

--- a/src/Kaleidoscope-LEDEffect-Rainbow.cpp
+++ b/src/Kaleidoscope-LEDEffect-Rainbow.cpp
@@ -4,60 +4,36 @@ namespace kaleidoscope {
 
 void LEDRainbowEffect::update(void) {
   uint16_t now = millis();
-  if ((now - rainbow_last_update) < rainbow_update_delay) {
+  if ((now - last_update) < update_delay) {
     return;
   } else {
-    rainbow_last_update = now;
+    hue += hue_steps;
+    last_update = now;
   }
 
-  cRGB rainbow = hsvToRgb(rainbow_hue, rainbow_saturation, rainbow_value);
-
-  rainbow_hue += rainbow_steps;
-  if (rainbow_hue >= 255) {
-    rainbow_hue -= 255;
-  }
+  cRGB rainbow = hsvToRgb(hue, saturation, brightness);
   ::LEDControl.set_all_leds_to(rainbow);
 }
-
-void LEDRainbowEffect::brightness(byte brightness) {
-  rainbow_value = brightness;
-}
-
-void LEDRainbowEffect::update_delay(byte delay) {
-  rainbow_update_delay = delay;
-}
-
 
 // ---------
 
 void LEDRainbowWaveEffect::update(void) {
   uint16_t now = millis();
-  if ((now - rainbow_last_update) < rainbow_update_delay) {
+  if ((now - last_update) < update_delay) {
     return;
   } else {
-    rainbow_last_update = now;
+    hue += hue_steps;
+    last_update = now;
   }
 
   for (uint8_t i = 0; i < LED_COUNT; i++) {
-    uint16_t key_hue = rainbow_hue + 16 * (i / 4);
-    if (key_hue >= 255)          {
+    uint16_t key_hue = hue + 16 * (i / 4);
+    if (key_hue >= 255) {
       key_hue -= 255;
     }
-    cRGB rainbow = hsvToRgb(key_hue, rainbow_saturation, rainbow_value);
+    cRGB rainbow = hsvToRgb(key_hue, saturation, brightness);
     ::LEDControl.setCrgbAt(i, rainbow);
   }
-  rainbow_hue += rainbow_wave_steps;
-  if (rainbow_hue >= 255) {
-    rainbow_hue -= 255;
-  }
-}
-
-void LEDRainbowWaveEffect::brightness(byte brightness) {
-  rainbow_value = brightness;
-}
-
-void LEDRainbowWaveEffect::update_delay(byte delay) {
-  rainbow_update_delay = delay;
 }
 }
 

--- a/src/Kaleidoscope-LEDEffect-Rainbow.cpp
+++ b/src/Kaleidoscope-LEDEffect-Rainbow.cpp
@@ -4,14 +4,18 @@ namespace kaleidoscope {
 
 void LEDRainbowEffect::update(void) {
   uint16_t now = millis();
-  if ((now - last_update) < update_delay) {
-    return;
+  if ((now - last_hue_update) < hue_update_interval) {
+    if (!breathe) { // no updates either due to hue change or breathing
+      return;
+    }
   } else {
     hue += hue_steps;
-    last_update = now;
+    last_hue_update = now;
   }
 
-  cRGB rainbow = hsvToRgb(hue, saturation, brightness);
+  cRGB rainbow = breathe ?
+                 breath_compute_helper(hue, saturation, now) :
+                 hsvToRgb(hue, saturation, brightness);
   ::LEDControl.set_all_leds_to(rainbow);
 }
 
@@ -19,11 +23,13 @@ void LEDRainbowEffect::update(void) {
 
 void LEDRainbowWaveEffect::update(void) {
   uint16_t now = millis();
-  if ((now - last_update) < update_delay) {
-    return;
+  if ((now - last_hue_update) < hue_update_interval) {
+    if (!breathe) { // no updates either due to hue change or breathing
+      return;
+    }
   } else {
     hue += hue_steps;
-    last_update = now;
+    last_hue_update = now;
   }
 
   for (uint8_t i = 0; i < LED_COUNT; i++) {
@@ -31,10 +37,13 @@ void LEDRainbowWaveEffect::update(void) {
     if (key_hue >= 255) {
       key_hue -= 255;
     }
-    cRGB rainbow = hsvToRgb(key_hue, saturation, brightness);
+    cRGB rainbow = breathe ?
+                   breath_compute_helper(key_hue, saturation, now) :
+                   hsvToRgb(key_hue, saturation, brightness);
     ::LEDControl.setCrgbAt(i, rainbow);
   }
 }
+
 }
 
 kaleidoscope::LEDRainbowEffect LEDRainbowEffect;

--- a/src/Kaleidoscope-LEDEffect-Rainbow.h
+++ b/src/Kaleidoscope-LEDEffect-Rainbow.h
@@ -10,13 +10,14 @@ class LEDRainbowEffect : public LEDMode {
   void update(void) final;
 
   int8_t hue_steps = 1;
-  uint8_t update_delay = 40;
+  uint8_t hue_update_interval = 40;
   uint8_t saturation = 255;
+  bool breathe = false;
   uint8_t brightness = 50;
 
  private:
   uint8_t hue = 0;
-  uint16_t last_update = 0;
+  uint16_t last_hue_update = 0;
 };
 
 
@@ -26,13 +27,14 @@ class LEDRainbowWaveEffect : public LEDMode {
   void update(void) final;
 
   int8_t hue_steps = 1;
-  uint8_t update_delay = 40;
+  uint8_t hue_update_interval = 40;
   uint8_t saturation = 255;
+  bool breathe = false;
   uint8_t brightness = 50;
 
  private:
   uint8_t hue = 0;
-  uint16_t last_update = 0;
+  uint16_t last_hue_update = 0;
 };
 }
 

--- a/src/Kaleidoscope-LEDEffect-Rainbow.h
+++ b/src/Kaleidoscope-LEDEffect-Rainbow.h
@@ -7,52 +7,32 @@ namespace kaleidoscope {
 class LEDRainbowEffect : public LEDMode {
  public:
   LEDRainbowEffect(void) {}
-
-  void brightness(byte);
-  byte brightness(void) {
-    return rainbow_value;
-  }
-  void update_delay(byte);
-  byte update_delay(void) {
-    return rainbow_update_delay;
-  }
   void update(void) final;
 
+  int8_t hue_steps = 1;
+  uint8_t update_delay = 40;
+  uint8_t saturation = 255;
+  uint8_t brightness = 50;
+
  private:
-  uint16_t rainbow_hue = 0;   //  stores 0 to 614
-
-  uint8_t rainbow_steps = 1;  //  number of hues we skip in a 360 range per update
-  uint16_t rainbow_last_update = 0;
-  uint16_t rainbow_update_delay = 40; // delay between updates (ms)
-
-  byte rainbow_saturation = 255;
-  byte rainbow_value = 50;
+  uint8_t hue = 0;
+  uint16_t last_update = 0;
 };
 
 
 class LEDRainbowWaveEffect : public LEDMode {
  public:
   LEDRainbowWaveEffect(void) {}
-
-  void brightness(byte);
-  byte brightness(void) {
-    return rainbow_value;
-  }
-  void update_delay(byte);
-  byte update_delay(void) {
-    return rainbow_update_delay;
-  }
   void update(void) final;
 
+  int8_t hue_steps = 1;
+  uint8_t update_delay = 40;
+  uint8_t saturation = 255;
+  uint8_t brightness = 50;
+
  private:
-  uint16_t rainbow_hue = 0;  //  stores 0 to 614
-
-  uint8_t rainbow_wave_steps = 1;  //  number of hues we skip in a 360 range per update
-  uint16_t rainbow_last_update = 0;
-  uint16_t rainbow_update_delay = 40; // delay between updates (ms)
-
-  byte rainbow_saturation = 255;
-  byte rainbow_value = 50;
+  uint8_t hue = 0;
+  uint16_t last_update = 0;
 };
 }
 

--- a/src/Kaleidoscope-LEDEffect-Rainbow.h
+++ b/src/Kaleidoscope-LEDEffect-Rainbow.h
@@ -18,6 +18,7 @@ class LEDRainbowEffect : public LEDMode {
  private:
   uint8_t hue = 0;
   uint16_t last_hue_update = 0;
+  uint16_t last_update = 0;
 };
 
 
@@ -35,6 +36,7 @@ class LEDRainbowWaveEffect : public LEDMode {
  private:
   uint8_t hue = 0;
   uint16_t last_hue_update = 0;
+  uint16_t last_update = 0;
 };
 }
 


### PR DESCRIPTION
Cleanups technically breaks API in the case of the brightness and update delay but makes for cleaner code and the fix on user side is minor.

Also exposes the saturation to the user which can be useful if they want more pastel colors.

The breathe addition depends on https://github.com/keyboardio/Kaleidoscope-LEDControl/pull/27 as it uses the new `breath_compute_helper` to avoid extra call to `millis()` for each LED in case of the wave effect.